### PR TITLE
stop logging to fluent

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,3 +1,0 @@
-export const FLUENT_PORT = 24224;
-export const FLUENT_HOST = 'localhost';
-export const FLUENT_TIMEOUT = 3.0;

--- a/index.ts
+++ b/index.ts
@@ -1,14 +1,11 @@
 import * as os from 'os';
 import * as path from 'path';
 
-import * as winston from 'winston';
 import fclone from 'fclone';
+import * as winston from 'winston';
 
 import { MetadataRewriter } from 'winston';
 import { argv } from 'yargs';
-import { FLUENT_HOST, FLUENT_PORT, FLUENT_TIMEOUT } from './constants';
-
-const fluentLogger = require('fluent-logger');
 
 require('winston-log-and-exit');
 
@@ -88,16 +85,5 @@ logger.add(winston.transports.Console, {
   timestamp: isProd,
   level: process.env.LOG_LEVEL || 'info',
 });
-
-if (isProd && !isECS) {
-  const fluentConfig = {
-    host: FLUENT_HOST,
-    port: FLUENT_PORT,
-    timeout: FLUENT_TIMEOUT,
-  };
-  const fluentTransport = fluentLogger.support.winstonTransport();
-  const transport = new fluentTransport('heap.coffee', fluentConfig);
-  logger.add(transport, null, true);
-}
 
 module.exports = logger;


### PR DESCRIPTION
getting `connect ECONNREFUSED ::1:24224` in kubernetes. i believe this is a carryover from the ec2 times. since it's disabled on ecs i don't think there's much risk with getting rid of it -- the only server group it might affect that i can think of is airflow but that shouldn't matter